### PR TITLE
3 bug fixes from Sean, as discussed via gmail/hangouts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "babel-preset-es2015": "^6.9.0",
     "browser-sync": "^2.11.0",
     "del": "^2.2.0",
+    "gh-pages": "^0.11.0",
     "gulp": "git://github.com/gulpjs/gulp.git#4.0",
+    "gulp-babel": "^6.1.2",
     "gulp-cache": "^0.4.1",
     "gulp-concat": "^2.6.0",
     "gulp-cssnano": "^2.1.0",
@@ -31,8 +33,6 @@
     "gulp-uglify": "^1.5.1",
     "require-dir": "^0.3.0",
     "shelljs": "^0.7.0",
-    "yargs": "^4.7.0",
-    "gulp-babel": "^6.1.2",
-    "gh-pages": "^0.11.0"
+    "yargs": "^4.7.0"
   }
 }

--- a/src/assets/scss/themestyle.scss
+++ b/src/assets/scss/themestyle.scss
@@ -579,6 +579,7 @@ h1.section-title:after,
 
 .main-slider {
     color: #fff;
+    pointer-events: none;
     text-align: center;
     text-transform: uppercase;
 }

--- a/src/assets/scss/themestyle.scss
+++ b/src/assets/scss/themestyle.scss
@@ -404,10 +404,6 @@ h1.section-title:after,
     border-top: 15px solid #f0f0f0;
 }
 
-.portfolio-wrapper {
-    text-align: center;
-}
-
 
 /* PORTFOLIO ITEM BUTTON OVERLAY */
 

--- a/src/index.html
+++ b/src/index.html
@@ -68,7 +68,7 @@ title: home
           <li>Create a Culture of Learning that fosters innovation and initiative for the long term.</li>
         </ul>
       </p>
-      <p>Get a <a href='https://github.com/jmmastey/jmmastey/raw/master/assets/jmastey-1page.pdf'>one-page version</a> of my services.</p>
+      <p>Get a <a href='https://raw.githubusercontent.com/jmmastey/jmmastey/jekyll/src/assets/jmastey-1page.pdf'>one-page version</a> of my services.</p>
     </div>
   </section>
 

--- a/src/index.html
+++ b/src/index.html
@@ -91,7 +91,7 @@ title: home
   </section>
 
   <!-- SKILLS -->
-  <section id="portfolio" class="portfolio-wrapper sect-1">
+  <section id="skills" class="sect-1">
     <div class="container">
       <div class="section-title">
         <h3 class="title">I'm also a software generalist</h3>


### PR DESCRIPTION
Summary of correspondence:

Bug 1:

For wide-viewports (header links uncollapsed by responsiveness), bxSlider's target ul is on top of both the header links and the "scroll for more" anchor, but only after the first bxSlider transition (the item after "HI, I'M JOE.").

Applying "pointer-events: none" to said ul fixes this issue as it allows the events to pass through z-wise, but I ultimately ended up applying this to .main-slider - the ul's parent.

Bug 2:

This is concerning the "scroll for more" anchor.  First of all, this has a dependency on Bug 1 as it also affects this anchor, covering it up after the first transition and making it unhoverable/unclickable.  Once that is taken care of, I found that the smooth scroll to the skills section didn't occur on click.  I noted the anchor had href="#skills" and that section#skills was non-existent, but section#portfolio occurred twice in sequence.  I assumed the first occurrence of section#portfolio was intended to be #skills, and that it was a simple case of copy-pasting section#portfolio in preparation for creating the skills section, but forgetting to change the id.

Changing the first #portfolio section to be #skills fixed the issue.

Bug 3:

The link for "Get a one-page version of my services." resulted in a 404.  I noticed github doesn't any longer have a "Raw" button when viewing pdf files in the repo browser, but they provide a download link using "raw" as subdomain and "githubusercontent" as domain.

Replacing the href on the offending anchor allows a pdf download without navigating away from your domain as well as resolving the 404.